### PR TITLE
2-LJEDD2

### DIFF
--- a/LJEDD2/BFS/게임 맵 최단거리.py
+++ b/LJEDD2/BFS/게임 맵 최단거리.py
@@ -1,0 +1,43 @@
+from collections import deque
+dx, dy = [-1, 1, 0, 0], [0, 0, -1, 1]
+
+def OOB(x, y):
+    global maps
+    n, m = len(maps), len(maps[0]) # MAP_SIZE = N X M
+    # 이동할 위치가 그래프 범위 내에 포함이 되는지 확인
+    return 0 <= x < n and 0 <= y < m
+
+def bfs(x, y):
+    global maps
+    # Queue
+    queue = deque([(x, y)])
+
+    while queue:
+        x, y = queue.popleft()
+        for d_x, d_y in zip(dx, dy):
+            # 다음 STEP 이동 (상,하,좌,우)
+            nx = x + d_x
+            ny = y + d_y
+
+            # 다음 이동 위치가 그래프 내에 있는지,
+            # 이동 가능한 (=1) 위치인지를 판단 (0은 이동할 수 없음)
+            if OOB(nx, ny) and maps[nx][ny] == 1:
+                # 칸 개수 +1 : 1이 아닐 경우 이미 방문했음(계속 ++1)을 알 수 있음
+                maps[nx][ny] = maps[x][y] + 1
+                #  그 다음 위치
+                queue.append((nx, ny))
+
+    # 최소비용 : 마지막 장소 maps[n][m]의 값
+    return maps[len(maps) - 1][len(maps[0]) - 1]
+
+
+def solution(board):
+    # 입력 받은 maps 전역변수 선언
+    global maps
+    maps = board.copy()
+
+    # 너비 우선 탐색 (BFS)
+    answer = bfs(0, 0)
+
+    return -1 if answer == 1 else answer # 결과 출력
+

--- a/LJEDD2/README.md
+++ b/LJEDD2/README.md
@@ -3,4 +3,6 @@
 | 차시 |    날짜    | 문제유형 | 링크 |                                  풀이                                   |
 |:----:|:---------:|:----:|:-----:|:---------------------------------------------------------------------:|
 | 1차시 | 2024.01.01 |  그리디  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/42883">큰 수 만들기</a>   | [#2](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/2) |
+| 2차시 | 2024.01.04 |  BFS  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/1844">게임 맵 최단거리</a>   | [#11](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/11) |
+
 ---


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!! 넵!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
###  **프로그래머스 코딩테스트 고득점 Kit - 깊이/너비 우선 탐색(DFS/BFS)** | [게임 맵 최단거리](https://school.programmers.co.kr/learn/courses/30/lessons/1844)


**문제 설명**
- 게임 맵의 상태 maps가 매개변수로 주어질 때, 캐릭터가 상대 팀 진영에 도착하기 위해 지나가야 하는 칸 개수의 `최솟값`을 결과로 출력 (상대 팀 진영에 도착할 수 없을 경우 -1을 출력)
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/78216102/95400d66-f696-451b-846e-6accc9ed23d1)


**제한 조건**
- maps는 n x m 크기의 게임 맵의 상태가 들어있는 2차원 배열로, 1 <= n,m <= 100
- maps는 0과 1로만 이루어져 있으며, 0은 벽이 있는 자리, 1은 벽이 없는 자리
- 캐릭터 첫 위치는 (0,0) 상대방 진영은 게임 맵의 우측 하단인 (n-1, m-1) 위치에 있다.

---

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
25분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

> 너비 우선 탐색 (BFS) 이란? 
그래프에서 가까운 노드부터 우선적으로 탐색한다. `큐` 자료구조를 이용해서 구현할 수 있으며 Python에서는` collections`의 `deque`를 사용하면 된다,

**✅ bfs의 기본적인 동작 원리**
1. 시작 노드를 **큐에 넣고 방문 처리**하기
2. 큐에서 노드를 꺼내고(`popleft()`) 인접 노드 중 방문하지 않은 노드를 큐에 넣고 **방문** 처리하기
3. 큐에 노드가 들어있지 않아 2번의 과정을 수행할 수 없을 때까지 2번 과정을 반복하기

### 1. 문제 지문 읽기 
- 문제에서 캐릭터는 동, 서, 남, 북(상하좌우)으로만 움직일 수 있다고 했다. 
- 캐릭터의 좌표를 저장하고 차례대로 꺼내 퍼트려나가면서 최단거리를 구해야하기 때문에 BFS로 풀었다. 
    - 각 위치에서 갈 수 있는 방향을 설정해줘야 하기 때문에, BFS에서 상하좌우를 확인하기 위한 dx, dy 리스트를 만든다. 
```python
dx, dy = [-1, 1, 0, 0], [0, 0, -1, 1]
```
-  maps는 n x m 크기의 게임 맵의 상태가 들어있는 2차원 배열
    - 캐릭터가 이동할 수 있는 범위가 가로로는 `M`까지 세로로는 `N`까지 이동이 가능하다는 말이다. 
    - 따라서, `out of bounds` 인지를 확인하는`OOB()`함수를 따로 만들어 두었다.
    
```python 
def OOB(x, y):
    global maps 
    n = len(maps)
    m = len(maps[0])
    # 그래프 범위 내에 포함이 되는지 확인
    return 0 <= x < n and 0 <= y < m
```

- maps는 0과 1로만 이루어져 있으며, 0은 벽이 있는 자리, 1은 벽이 없는 자리이다.
    - `0`과 `1`로 **애초에 갈 수 있는지 없는지**를 판단할 수 있다
    -  숫자형이기 때문에 +1 해주면서 1인 경우를 **방문 가능한 곳 중 한번도 방문하지 않은 곳**, 1 이상인 경우를 **방문 가능한 곳 중 이미 방문하여 거리를 계산한 곳**으로 구분을 해줄 수 있었다. 

### 2. BFS 
- Queue 자료구조는 기본적으로 **선입선출**이기 때문에 제일 먼저 넣은 값이 제일 먼저 나온다. 
- 따라서 queue 객체를 생성하고 시작 지점의 위치를 큐에 넣고 상하좌우를 확인한다. 

```python

def bfs(x, y):
    global maps
    # Queue
    queue = deque([(x, y)])

    while queue:
        # 현재 위치에 대한 x,y값 pop
        x, y = queue.popleft()

        for d_x, d_y in zip(dx, dy):
            # 다음 STEP 이동 (상,하,좌,우)
            nx = x + d_x
            ny = y + d_y

            # 다음 이동 위치(nx, ny)가 그래프 내에 있는지,
            # 이동 가능한 (=1) 위치인지를 판단 (0은 이동할 수 없음)
            if OOB(nx, ny) and maps[nx][ny] == 1:
                # 칸 개수 +1 : 1이 아닐 경우 이미 방문했음(계속 ++1)을 알 수 있음
                maps[nx][ny] = maps[x][y] + 1
                #  그 다음 위치
                queue.append((nx, ny))
```

- 처음 방문한 칸이면 첫 번째 칸(문제에서는 (1, 1)이지만 (0, 0)으로 계산)부터 이 칸까지의 거리를 계산하여 갱신한다. 
- 상하좌우로 그 다음 위치를 파악하여 현재 좌표에 방향을 적용했을 때 방문할 수 있다면 현재 위치에 1을 더한 값을 넣어 몇 칸을 거쳐왔는지 표시해주면 된다.
    - 방문할 수 있는 칸의 거리를 갱신함과 동시에 다음 좌표 `(nx,ny)`를 큐에 넣는다. 

```python
예시 )
1) 두 갈래 길을 만났을 때. 좌표가 모두 저장 : [(1,2), (2,3)]
2) 두 방향으로 이동하면서 동시에 좌표를 계속 저장하기를 반복 
- pop : 1, 2 [(2,3)] <- (0,2)
- pop : 2, 3 [(0,2)] <- (2,4)
- pop : 0, 2 [(2,4)] <- (0,3)
- pop : 2, 4 [(0,3)] <- (1,4), (3,4) 
- pop : 0, 3 [(1,4), (3,4)] <- (0,4), (4,4)
- pop : 1, 4 [(3,4), (0,4), (4,4)]
- ...
- pop : 0, 4 [(4,4)]  <- ✨이미 (0,3)을 pop하여 방문하였거나 그래프 밖을 벗어나기 때문에 더 이상의 append 없음 
- pop : 4, 4 (이 때, 이동거리 11칸)

```
위의 구체적인 동작 과정을 그림으로 보면 다음과 같다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/78216102/4075510c-fce4-427a-94b6-2b3206cda443)

이렇게 모든 **이동 가능한** 칸의 거리 계산이 끝났으면 제일 오른쪽 아래 칸의 이동 비용 값을 반환한다.
목표지의 값이 0이거나 1이면 도달하지 못한 것이므로 이 때 -1을 반환해주면 된다.

### 3. 전체 코드
```python
from collections import deque
dx, dy = [-1, 1, 0, 0], [0, 0, -1, 1]

def OOB(x, y):
    global maps
    n, m = len(maps), len(maps[0]) # MAP_SIZE = N X M
    # 이동할 위치가 그래프 범위 내에 포함이 되는지 확인
    return 0 <= x < n and 0 <= y < m

def bfs(x, y):
    global maps
    # Queue
    queue = deque([(x, y)])

    while queue:
        # 현재 위치에 대한 x,y값 pop
        x, y = queue.popleft()

        for d_x, d_y in zip(dx, dy):
            # 다음 STEP 이동 (상,하,좌,우)
            nx = x + d_x
            ny = y + d_y

            # 다음 이동 위치(nx, ny)가 그래프 내에 있는지,
            # 이동 가능한 (=1) 위치인지를 판단 (0은 이동할 수 없음)
            if OOB(nx, ny) and maps[nx][ny] == 1:
                # 칸 개수 +1 : 1이 아닐 경우 이미 방문했음(계속 ++1)을 알 수 있음
                maps[nx][ny] = maps[x][y] + 1
                #  그 다음 위치
                queue.append((nx, ny))

    # 최소비용 : 마지막 장소 maps[n][m]의 값
    return maps[len(maps) - 1][len(maps[0]) - 1]


def solution(board):
    # 입력 받은 maps 전역변수 선언
    global maps
    maps = board.copy()

    # 너비 우선 탐색 (BFS)
    answer = bfs(0, 0)

    return -1 if answer == 1 else answer # 결과 출력
```



## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

[[이것이 코딩 테스트다 with Python] 19강 BFS 알고리즘](https://www.youtube.com/watch?v=CJiF-muKz30)

[원격 저장소에 올라간 커밋 되돌리기](https://jupiny.com/2019/03/19/revert-commits-in-remote-repository/)
실수로 1회차 브런치에 커밋을 남겼고 이를 돌리기 위해 많은 시행착오를 겪었다.
깃허브의 commit을 원하는 위치로 되돌리고 origin branch에 적용하는 방법을 알게 되었다. 

```
$ git log -> 되돌리고 싶은 커밋의 주소 확인
$ git reset --hard [커밋 주소] -> 내가 되돌리고 싶은 커밋으로 이동 (로컬)
$ git push <-f 또는 --force> origin [1-LJEDD2]
-> 로컬 저장소의 커밋 히스토리가 원격 저장소의 커밋 히스토리보다 뒤쳐져 있기 때문에 강제로 덮어쓰기 
```


+) 2024-01-05 새로 알게 된 내용 추가
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/78216102/06f011e3-7a4c-4a5b-9f2f-93fdec27d9de)

- `git revert` : 특정 커밋에서의 변경 사항을 제거하는 또 다른 커밋을 생성하는 명령어
    - 특정 커밋을 되돌리는 작업도 하나의 커밋으로 간주
    -  커밋 히스토리에 변경 내역을 추가하는 것이므로, 내가 되돌린 작업을 다른 팀원들과도 공유할 수 있게 된다. 
- `git reset` : 내가 되돌리고 싶은 커밋들을 되돌린다.
    - 나 혼자만 사용하는 브랜치에 커밋을 push하였고, 이를 되돌리고 싶은 경우
    - 팀원들과 직접 커뮤니케이션해서 내가 되돌린 커밋을 pull로 땡겨간 팀원이 없다고 확인된 경우에만 사용한다. 