### PR TITLE
2-Hwangyerin

### DIFF
--- a/Hwangyerin/README.md
+++ b/Hwangyerin/README.md
@@ -3,5 +3,5 @@
 | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
 |:----:|:---------:| :----:|:-----:|:----:|
 | 1차시 | 2024.01.01 |  스택  | <a href=https://school.programmers.co.kr/learn/courses/30/lessons/12909>올바른 괄호</a>  | [#3](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/3) |
-| 2차시 | 2024.01.04 |  큐  | <a https://www.acmicpc.net/problem/1158>요세푸스 문제</a>  | [#12]() |
+| 2차시 | 2024.01.04 |  큐  | <a https://www.acmicpc.net/problem/1158>요세푸스 문제</a>  | [#12](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/12) |
 ---

--- a/Hwangyerin/README.md
+++ b/Hwangyerin/README.md
@@ -3,4 +3,5 @@
 | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
 |:----:|:---------:| :----:|:-----:|:----:|
 | 1차시 | 2024.01.01 |  스택  | <a href=https://school.programmers.co.kr/learn/courses/30/lessons/12909>올바른 괄호</a>  | [#3](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/3) |
+| 2차시 | 2024.01.04 |  큐  | <a https://www.acmicpc.net/problem/1158>요세푸스 문제</a>  | [#12]() |
 ---

--- a/Hwangyerin/큐/요세푸스 문제.py
+++ b/Hwangyerin/큐/요세푸스 문제.py
@@ -1,0 +1,11 @@
+from collections import deque
+n,k=[int(x) for x in input().split()]
+answer = []
+queue=deque([i for i in range(1,n+1)])
+
+while queue:
+    for i in range(k-1):
+        queue.append(queue.popleft())
+    answer.append(queue.popleft())
+answer = str(answer)[1:-1]
+print("<" + answer + ">")


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
### BAEKJOON | [요세푸스 문제](https://www.acmicpc.net/problem/1158)
**문제**
요세푸스 문제는 다음과 같다.

1번부터 N번까지 N명의 사람이 원을 이루면서 앉아있고, 양의 정수 K(≤ N)가 주어진다. 이제 순서대로 K번째 사람을 제거한다. 한 사람이 제거되면 남은 사람들로 이루어진 원을 따라 이 과정을 계속해 나간다. 이 과정은 N명의 사람이 모두 제거될 때까지 계속된다. 원에서 사람들이 제거되는 순서를 (N, K)-요세푸스 순열이라고 한다. 예를 들어 (7, 3)-요세푸스 순열은 <3, 6, 2, 7, 5, 1, 4>이다.

N과 K가 주어지면 (N, K)-요세푸스 순열을 구하는 프로그램을 작성하시오.

**입력**
첫째 줄에 N과 K가 빈 칸을 사이에 두고 순서대로 주어진다. (1 ≤ K ≤ N ≤ 5,000)

**출력**
<3, 6, 2, 7, 5, 1, 4> 와 같이 출력한다.

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
30분
## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
1번부터 N번까지 N명의 사람이 원을 이루면서 앉아있다는 문장을 봤을 때, 머릿 속에서는 이미 원형의 테이블이 그려진다. 
원형은 시작과 끝이 없는 구조이기 때문에 양 끝에서 삽입, 삭제할 수 있는 큐로 구현하기 좋다.
이 문제는 시각적으로 이해하기 편하다.
![제목을-입력해주세요_-001](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/50723984/308e3fab-9f8c-4f9e-8588-ef7b553f5bb0)


### ✨ 수도 코드
1. 1부터 N까지 들어있는 덱을 생성한다.
2. k번째 사람을 제거하기 위해 (k-1)번까지의 데이터를 앞에서 뽑아`popleft()` 뒤로 붙여준다.`.append()`(인덱스의 시작은 1이 아닌 0이기 때문에 k가 아닌 k-1이다.)

3. 2의 과정을 거치면 맨 왼쪽에(덱[0]) k번째 사람이 오게되며, 순열을 출력해야하기 때문에 맨 왼쪽에 있는 k번째 사람을 제거하고 임의의 리스트에 추가해준다.

4. 2,3과정을 기존에 생성한 덱의 길이가 0보다 클 때까지 반복한다.

> #### 왜 리스트가 아닌 덱을 생성하는가?
덱은 Double Ended Queue를 줄인 말로 양 끝에서 삽입이나 삭제할 수 있는 큐를 구현한 것이다.
이 특징 때문에 큐를 구현할 때는 덱을 사용하는 것이 좋다.
```Python
from collections import deque

queue = deque()

#데이터 추가
queue.append(1)

#큐의 맨 앞 데이터 제거
queue.popleft()
```

> #### 큐를 구현하는데 pop(0)를 놔두고 굳이 덱의 popleft()함수를 사용하는 이유는? 
`pop()`같은 경우의 시간복잡도는 **O(1)** 이지만, 특정 인덱스의 원소를 삭제하기 위해서는 그 원소 뒤의 모든 원소들을 한 칸씩 옮겨야하기 때문에 시간복잡도는 **O(n)** 이다. 반대로 덱의 `popleft()`함수는 O(1)의 빠른 복잡도로 원소 삭제가 가능하다.

### 🗝️최종 코드
```Python
from collections import deque
n,k=[int(x) for x in input().split()]
answer = []

#1부터 n까지 deque에 추가
queue=deque([i for i in range(1,n+1)])

#deque의 모든 요소가 사라질 때까지 반복
while queue:
    #k번째 요소를 찾는 과정
    for i in range(k-1):
        queue.append(queue.popleft())
    answer.append(queue.popleft()) #queue에서 k번째 요소 제거후 answer에 추가

#answer데이터 형식 string으로 변경 후 대괄호 제외한 나머지 값 대입
answer = str(answer)[1:-1]

print("<" + answer + ">")
```

### 📢코드 부가설명
answer = str(answer)[1:-1]
리스트 요소가 int형일 경우 ''.join()이 사용 불가능 하다.
그래서 찾은 방법.! 예를들어 리스트 [1,2,3,4]를 string으로 바꿔주고 인덱싱을 대괄호를 제외한 [1:-1]으로 해주게 된다면!
`print(answer)`할 경우 1,2,3,4만 출력된다! 

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

- [큐 개념 및 구현 방법](https://product.kyobobook.co.kr/detail/S000210881884)
- [큐를 구현하는데 pop(0)를 놔두고 굳이 덱의 popleft()함수를 사용하는 이유](https://velog.io/@yoouung/Python-pop0-vs.-popleft)
- [파이썬 리스트 괄호없이 출력](https://velog.io/@zh025700/%ED%8C%8C%EC%9D%B4%EC%8D%AC-%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EA%B4%84%ED%98%B8%EC%97%86%EC%9D%B4-%EC%B6%9C%EB%A0%A5)