### PR TITLE
14-LJEDD2

### DIFF
--- a/LJEDD2/README.md
+++ b/LJEDD2/README.md
@@ -13,5 +13,5 @@
 | 9차시 | 2024.01.25 |  SQL  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/157339">특정 기간동안 대여 가능한 자동차들의 대여비용 구하기</a>   | [#38](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/38) |
 | 10차시 | 2024.01.28 |  DFS  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/84512">모음 사전</a>   | [#43](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/43) |
 | 11차시 | 2024.01.31 |  그리디  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/42885">구명보트</a>   | [#45](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/45) |
-| 12차시 | 2024.02.03 |  백트래킹  | <a href="https://www.acmicpc.net/problem/26170">사과 빨리 먹기</a>   | [#47](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/47) |
+| 12차시 | 2024.02.03 |  백트래킹  | <a href="https://www.acmicpc.net/problem/26170">사과 빨리 먹기</a>   | [#50](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/50) |
 ---

--- a/LJEDD2/README.md
+++ b/LJEDD2/README.md
@@ -15,6 +15,7 @@
 | 11차시 | 2024.01.31 |  그리디  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/42885">구명보트</a>   | [#45](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/45) |
 | 12차시 | 2024.02.03 |  백트래킹  | <a href="https://www.acmicpc.net/problem/26170">사과 빨리 먹기</a>   | [#50](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/50) |
 | 13차시 | 2024.02.06 |  백트래킹  | <a href="https://www.acmicpc.net/problem/26169">세 번 이내에 사과를 먹자</a>   | [#54](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/54) |
+| 14차시 | 2024.02.09 |  다익스트라  | <a href="https://www.acmicpc.net/problem/13549">숨바꼭질 3</a>   | [#59](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/59) |
 
 
 ---

--- a/LJEDD2/README.md
+++ b/LJEDD2/README.md
@@ -14,4 +14,7 @@
 | 10차시 | 2024.01.28 |  DFS  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/84512">모음 사전</a>   | [#43](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/43) |
 | 11차시 | 2024.01.31 |  그리디  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/42885">구명보트</a>   | [#45](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/45) |
 | 12차시 | 2024.02.03 |  백트래킹  | <a href="https://www.acmicpc.net/problem/26170">사과 빨리 먹기</a>   | [#50](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/50) |
+| 13차시 | 2024.02.06 |  백트래킹  | <a href="https://www.acmicpc.net/problem/26169">세 번 이내에 사과를 먹자</a>   | [#54](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/54) |
+
+
 ---

--- a/LJEDD2/README.md
+++ b/LJEDD2/README.md
@@ -13,4 +13,5 @@
 | 9차시 | 2024.01.25 |  SQL  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/157339">특정 기간동안 대여 가능한 자동차들의 대여비용 구하기</a>   | [#38](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/38) |
 | 10차시 | 2024.01.28 |  DFS  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/84512">모음 사전</a>   | [#43](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/43) |
 | 11차시 | 2024.01.31 |  그리디  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/42885">구명보트</a>   | [#45](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/45) |
+| 12차시 | 2024.02.03 |  백트래킹  | <a href="https://www.acmicpc.net/problem/26170">사과 빨리 먹기</a>   | [#47](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/47) |
 ---

--- a/LJEDD2/다익스트라/숨바꼭질3.py
+++ b/LJEDD2/다익스트라/숨바꼭질3.py
@@ -1,0 +1,57 @@
+# 다익스트라 
+import heapq
+import sys
+input = sys.stdin.readline
+
+INF = float('inf')
+n, k = map(int,input().split())
+
+# 시작 위치 초기화
+board = [INF] * 100001
+def OOB(x):
+    return not(0 <= x <= 100000)
+
+# 다익스트라
+def dijkstra(start):
+    q = []
+
+    # 시작 노드로 가기 전 최단 경로를 0으로 설정, 큐 삽입
+    heapq.heappush(q,(0,start))
+    board[start] = 0
+
+    while q:
+        dist, now = heapq.heappop(q)
+
+        # 이미 갱신된 적이 있는 노드일 경우 무시
+        if board[now] < dist:
+            continue
+
+        for jump, time in [(now*2, dist),(now+1, dist+1),(now-1, dist+1)]:
+            if not OOB(jump) and board[jump] > time:
+                board[jump] = time
+                heapq.heappush(q,(time,jump))
+
+dijkstra(n)
+print(board[k])
+
+# BFS 
+from collections import deque
+
+def bfs(x):
+    board = [-1] * 100001
+    queue = deque([x])
+    board[x] = 0
+
+    while queue:
+        c_x = queue.popleft()
+        if c_x == k:
+            return board[c_x]
+
+        # 0초 이동 먼저
+        # x + 1을 x - 1보다 먼저 넣으면 순간이동한 경우보다 빠르게 도착할 수 있기 때문에 오답 
+        for n_x in [c_x*2, c_x-1, c_x+1]:
+            if 0 <= n_x <= 100000 and board[n_x] == -1:
+                board[n_x] = board[c_x] + (0 if n_x == c_x*2 else 1)
+                queue.append(n_x)
+
+print(bfs(n))

--- a/LJEDD2/백트래킹/사과 빨리 먹기.py
+++ b/LJEDD2/백트래킹/사과 빨리 먹기.py
@@ -1,0 +1,85 @@
+import sys
+input = sys.stdin.readline
+
+board = [list(map(int,input().split())) for i in range(5)]
+visited = [[0]*5 for _ in range(5)]
+dx, dy = [0,0, -1, 1], [-1, 1, 0, 0]
+s_x,s_y = map(int,input().split())
+cnt = 99999
+
+def OOB(x,y):
+    return 0 <= x < 5 and 0 <= y < 5
+def dfs(x,y,apple, dist):
+    global cnt
+    # 사과를 3개 가져가면 return - 이동 횟수 저장 및 초기화
+
+    if apple == 3:
+        cnt = min(cnt,dist)
+
+    for d_x, d_y in zip(dx,dy):
+        nx = x + d_x
+        ny = y + d_y
+        if OOB(nx,ny) and not visited[nx][ny] and board[nx][ny] != -1 :
+            # 일단 한번 가봐야하니까 방문 찍고 탐색
+            visited[nx][ny] = 1
+            if board[nx][ny]:
+                apple += 1
+                apple_status = True
+
+            else:
+                apple_status = False
+
+            dfs(nx, ny, apple ,dist + 1)
+
+            # *지나온 길은 다시 되돌아갈 수 없고*, -1의 경우에는 아예 지나갈 수 없다
+            # -> 탐색만 하고 다시 원상태로 돌아와야함 (백트래킹)
+            visited[nx][ny] = 0
+
+            # 백트래킹을 할 때는 특정 칸을 탐색한 후에 그 칸을 초기 상태로 되돌려 줘야 한다.
+            if apple_status:
+                apple -= 1
+    return
+
+
+visited[s_x][s_y] = 1
+dfs(s_x,s_y,0,0)
+print(cnt if cnt != 99999 else -1)
+
+
+# 삽질 코드
+# import sys
+# from collections import deque
+# input = sys.stdin.readline
+#
+# board = [list(map(int,input().split())) for i in range(5)]
+# dx, dy = [0,0, -1, 1], [-1, 1, 0, 0]
+# s_x,s_y = map(int,input().split())
+# cnt = []
+#
+# def OOB(x,y):
+#     return 0 <= x < 5 and 0 <= y < 5
+#
+# def bfs(x,y):
+#     global cnt
+#     queue = deque([(x,y)])
+#
+#     apple = 0
+#     # 큐가 빌 때까지 반복
+#     while queue:
+#         x, y = queue.popleft()
+#
+#         for d_x, d_y in zip(dx,dy):
+#             nx = x + d_x
+#             ny = y + d_y
+#
+#             if OOB(nx,ny) and board[nx][ny] != -1:
+#                 if board[nx][ny]:
+#                     apple += 1
+#                     if apple == 3:
+#                         cnt.append(board[x][y] + 1)
+#
+#                 board[nx][ny] = board[x][y] + 1
+#                 queue.append((nx, ny))
+#     return
+# bfs(s_x, s_y)
+# print(cnt)

--- a/LJEDD2/백트래킹/사과 빨리 먹기.py
+++ b/LJEDD2/백트래킹/사과 빨리 먹기.py
@@ -15,6 +15,7 @@ def dfs(x,y,apple, dist):
 
     if apple == 3:
         cnt = min(cnt,dist)
+        return 
 
     for d_x, d_y in zip(dx,dy):
         nx = x + d_x

--- a/LJEDD2/백트래킹/세 번 이내에 사과를 먹자.py
+++ b/LJEDD2/백트래킹/세 번 이내에 사과를 먹자.py
@@ -1,0 +1,47 @@
+input = open(0).readline
+board = [list(map(int, input().split())) for _ in range(5)]
+visited = [[col == -1 for col in row] for row in board]
+r,c = map(int,input().split())
+
+offset = [(-1,0),(0,1),(1,0),(0,-1)]
+visited[r][c] = True
+
+def out_of_bound(x: int, y: int) -> bool:
+    return not(0 <= x <= 4 and 0 <= y <= 4)
+
+def dfs(x: int, y: int, step: int = 0, apple: int = 0) -> bool:
+
+    # 1 과 0의 경우를 판단
+    if apple >= 2 and step <= 3: # 사과 2개를 3 스텝 이내에 먹었다면 참
+        return True
+    if apple < 2 and step > 3: # 3 스텝이 지날 동안 사과 2개도 못먹었다면 거짓
+        return False
+
+    # 4방향 탐색
+    for dx, dy in offset:
+        nx, ny = x + dx, y + dy
+
+        if out_of_bound(nx, ny) or visited[nx][ny]:
+            continue
+        visited[nx][ny] = True
+
+        # 이 다음 호출에서 반환되는 값이 참이면 return
+        if dfs(nx, ny, step + 1, apple + board[nx][ny]):
+            return True
+
+        # 되돌아옴
+        visited[nx][ny] = False
+
+    # 만족스러운 답을 찾지 못했을 경우 False 리턴
+    return False
+
+print(int(dfs(r, c)))
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
# 명절 특집
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
###  **백준 - 다익스트라/BFS** | [숨바꼭질 3](https://www.acmicpc.net/problem/13549)

**문제 설명**
- N(0 ≤ N ≤ 100,000)과  K(0 ≤ K ≤ 100,000)가 주어졌을 때 걷거나 순간이동하여 K에 도달할 수 있는 가장 빠른 시간을 구해라.
- 위치가 X일 때 걷는다면 `1`초 후에 `X-1` 또는 `X+1`로 이동한다.
- 순간이동을 하는 경우에는 `0`초 후에 `2*X`의 위치로 이동하게 된다.

**제한 조건**
-  N과 K는 정수이다.

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
3시간 

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

### 1. 문제 지문 읽기 
- 위치가 X일 때 걷는다면 `1`초 후에 `X-1` 또는 `X+1`로 이동한다.
- 순간이동을 하는 경우에는 `0`초 후에 `2*X`의 위치로 이동하게 된다.
- 가장 빠르게 도달하는 시간이 몇 초인지 찾는다. 

### 2. bfs 1차 시도 (무한 삽질의 서막)

2달전 시도했다가 광탈당한 문제를 다익스트라를 공부하며 다시 들여다보게 되었다. 
bfs로 문제를 해결하려 했지만 계속해서 틀렸습니다가 나와서 다른 사람의 풀이를 참고했다.
근데 이게 웬걸? 아무리 봐도 차이가 없는 것 같았는데 아주 크나큰 차이가 있었다. 

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/78216102/0e4ef09d-70eb-4e0a-b0dc-0b71096aee49)

[x + 1, x - 1 순서에 따라서 답이 달라지는 이유](https://www.acmicpc.net/board/view/127319)
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/78216102/0f4c8cd8-3414-46f8-81d1-9c644cb6167e)

- 간선의 길이가 다양하기에 처음 찾은 경로는 최단 경로가 아닐 수 있음을 간과하였다.
- 현재 위치에서 2배 점프한 경우 (가중치 0) 보다 빨리 K에 도달하게 되면 오답이 된다는 점. 

```python
        for nx in [cx*2, cx+1, cx-1]: # +1로 *2보다 빠르게 도달할 경우 오답 
            if (0 <= nx <= 100000) and board[nx] == -1:
                queue.append(nx)
                board[nx] = board[cx] + (0 if nx == cx*2 else 1)
```

-> 갱신 조건을 “-1이 아니면“이 아니라 **역대 최단거리보다 가까우면**으로 지정해야 한다.
특정한 노드에서 다른 노드로 가는 비용을 계산하여 최단 거리 테이블을 갱신하는 다익스트라 최단 경로 알고리즘이 필요하다. 

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/78216102/bcf8c1a1-5a72-41da-9430-034e2607bfa6)


### 3. 다익스트라 풀이 
> 다익스트라 최단 경로 알고리즘란? 

![Dijkstra_Animation](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/78216102/53a26058-7e72-4be0-8602-7d48c9e7a77e)
[출처](https://ko.wikipedia.org/wiki/%EB%8D%B0%EC%9D%B4%ED%81%AC%EC%8A%A4%ED%8A%B8%EB%9D%BC_%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98)

**💡 다익스트라 알고리즘 원리**
1) 출발 노드를 설정한다. 
2) 최단 거리 테이블을 초기화한다. 
3) 방문하지 않은 노드 중 최단거리가 가장 짦은 노드를 선택한다. 
4) 해당 노드를 거쳐 다른 노드로 가는 비용을 계산하여 최단 거리 테이블을 갱신한다. 
5) 3번과 4번을 반복한다. 

-> 임의의 노드 X에 연결된 노드 X-1, X+1, X*2 사이의 최소 경로를 구한다. 
최단 경로를 구하는 과정에서 `각 노드에 대한 현재까지의 가장 최단의 거리` 정보를 저장해나간다. 
**현재 처리하고 있는 노드와 인접한 노드로 가는 더 짧은 경로가 있다?** 그러면 **그 경로를 더 짧은 경로라고 판단하는 것**이다. 
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-4/assets/78216102/3d244674-760f-460b-9257-17411d4fc62d)

-> 이렇게 알고리즘 수행 후 N에서 K로 가는 최소 경로를 출력한다. 


#### 🤔 우선순위 큐를 이용하여 거리 순서로 노드 정보를 정렬하기
> 통상적으로 조금 더 빠르게 동작하는 heapq를 활용한 방식 
데이터 개수가 N개일 때, 하나의 데이터를 삽입 및 삭제할 때 시간복잡도가 O(logN) 

**개선된 다익스트라** 
- 파이썬의 heapq 라이브러리를 활용
- 첫번째 원소를 기준으로 우선순위 큐를 구성
- 따라서 (거리, 이동할 노드 번호) 순서로 튜플을 구성하여 우선 순위 큐를 구성하여 거리 순으로 가까운 노드 번호를 찾음 
- 거리가 가장 짧은 노드를 찾는 과정을 우선순위 큐를 활용하는 방법으로 대체 가능 

```python
import heapq
...

def dijkstra(start):
    q = []
    # 시작 노드로 가기 전 최단 경로를 0으로 설정, 큐 삽입
    heapq.heappush(q,(0,start))
    board[start] = 0
```

- 우선순위 큐에서 원소를 꺼내 각 노드로 가는 최소비용을 구한다. 
- 더 짧은 경로를 찾았을 때, 거리 테이블 갱신 + 노드의 정보를 우선순위 큐에 저장한다.  
- 위 단계를 반복한 후 최단 거리 테이블에 남아 있는 최단 거리를 출력한다. 



```python
 while q:
        dist, now = heapq.heappop(q)

        # 이미 갱신된 적이 있는 노드일 경우 무시
        if board[now] < dist:
            continue

        for jump, time in [(now*2, dist),(now+1, dist+1),(now-1, dist+1)]:
            if not OOB(jump) and board[jump] > time:
                board[jump] = time
                heapq.heappush(q,(time,jump))
```



### 4. 전체 코드

```python 
import heapq
import sys
input = sys.stdin.readline

INF = float('inf')
n, k = map(int,input().split())

# 시작 위치 초기화
board = [INF] * 100001
def OOB(x):
    return not(0 <= x <= 100000)

# 다익스트라
def dijkstra(start):
    q = []
    # 시작 노드로 가기 전 최단 경로를 0으로 설정, 큐 삽입
    heapq.heappush(q,(0,start))
    board[start] = 0

    while q:
        dist, now = heapq.heappop(q)

        # 이미 갱신된 적이 있는 노드일 경우 무시
        if board[now] < dist:
            continue

        for jump, time in [(now*2, dist),(now+1, dist+1),(now-1, dist+1)]:
            if not OOB(jump) and board[jump] > time:
                board[jump] = time
                heapq.heappush(q,(time,jump))

dijkstra(n)
print(board[k])
```

```python
from collections import deque

def bfs(n,k):
    queue = deque([n])
    board[n] = 0

    while queue:
        cx = queue.popleft()

        if cx == k:
            return ;
        for nx in [cx*2, cx+1, cx-1]:
            if (0 <= nx <= 100000) and board[nx] == -1:
                queue.append(nx)
                board[nx] = board[cx] + (0 if nx == cx*2 else 1)

n, k = map(int,input().split())
board = [-1] * 100001
bfs(n, k)
print(board[k])
```







## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->


참고
- 이것이 코딩 테스트다 with 파이썬 - Chapter 9 : 최단 경로 
- [백준 질문 게시판 답변들 참고](https://www.acmicpc.net/board/view/38887)