### PR TITLE
22-LJEDD2

### DIFF
--- a/LJEDD2/README.md
+++ b/LJEDD2/README.md
@@ -23,4 +23,5 @@
 | 19차시 | 2024.02.24 |  구현  | <a href="https://www.acmicpc.net/problem/16919">봄버맨 2</a>  | [#76](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/76) |
 | 20차시 | 2024.02.27 |  BFS  | <a href="https://www.acmicpc.net/problem/6593">상범 빌딩 2</a>  | [#80](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/80) |
 | 21차시 | 2024.03.01 |  정수론  | <a href="https://www.acmicpc.net/problem/21920">서로소 평균 2</a>  | [#83](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/83) |
+| 22차시 | 2024.03.04 |  수학(애드 혹)  | <a href="https://www.acmicpc.net/problem/28419">더하기 </a>  | [#88](https://github.com/AlgoLeadMe/AlgoLeadMe-4/pull/88) |
 ---

--- a/LJEDD2/애드 혹/더하기.py
+++ b/LJEDD2/애드 혹/더하기.py
@@ -1,0 +1,10 @@
+n = int(input())
+n_list = list(map(int,input().split()))
+diff = sum(n_list[1::2]) - sum(n_list[::2])
+
+# N=3이고 홀수합이 더 많다면 불가능
+if n == 3 and diff < 0 :
+    print(-1)
+# 그 외에는 절댓값의 차이 만큼 +1
+else:
+    print(abs(diff))


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

🎃 SQLD 시험 이슈로 ... 쉬운 수학문제를 풀었슴니다 😭😭😭 죄송함니다 
 
## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->

###  **백준 - 수학** | [더하기](https://www.acmicpc.net/problem/28419)

**문제 설명**
- 정수로 구성된 수열 A_1, A_2 , .. , A_N이 주어진다. 우리는 이 수열에 아래 연산을 원하는 만큼 반복할 수 있다.
- 인접한 세 값을 1씩 증가시킨다.
- 이 연산을 최소한으로 사용해 수열의 홀수 번째 위치의 합과 짝수 번째 위치의 합을 같게 만든다. 
- 최소 몇 번의 연산을 해야 홀수 번째 위치와 짝수 번째 위치의 합이 같아지는지 계산한다. 
- 홀수 번째 위치의 합과 짝수 번째 위치의 합을 같게 만들 수 없다면 -1을 출력한다.

**제한 조건**
- N은 3부터 10만까지 

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
50분 

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

### 1. 문제 지문 읽기 
- 인접한 3개의 숫자를 `1`씩 올리는 과정을 최소로 반복하여 합이 같게 만들어야 한다. 
- 연산을 1번 할 때마다 `짝수의 합 + 2` & `홀수의 합 + 1` 또는 `짝수의 합 +1` & `홀수의 합 +2` 를 비교하면 된다. 
→ 홀수의 합과 짝수의 합을 같게 만드는 문제이다. 

따라서 짝수합과 홀수합의 차이만큼 연산을 반복해주면 되는데, 만약 세 개 숫자만 있다면 `짝수의 합 + 1` 과 `홀수의 합 +2`의 경우만 가능하다. 
→ N = 3일때에는 홀수의 합이 더 크다면 같게 만들 수 없다.

예를 들자면,
세 개의 숫자가 각각 `[1, 2, 3]`이라고 가정할 때.
이 경우 홀수의 합은 `1 + 3 = 4`이고, 짝수의 합은 `2`가 된다. 

주어진 연산을 사용하여 세 개의 숫자를 같게 만들려고 해도, 홀수의 합이 계속해서 더 커지기 때문에 짝수의 합이 따라잡을 수 없다.

따라서 해당 조건을 추가해준 뒤 짝수합과 홀수합의 차이 (절댓값)를 출력해주면 된다.
 
### 1-1. 🎃 꿀팁
- 파이썬의 리스트 슬라이싱의 가능 범위는 한 단계도 가능하고 징검다리 식으로도 범위를 지정할 수 있다.
- 홀수 번째, 짝수 번째를 간단히 슬라이싱으로 추출하여 합계를 구해볼 수 있다 ! 
 
```python
diff = sum(n_list[1::2]) - sum(n_list[::2])
```

### 2. 전체 코드 
```python
n = int(input())
n_list = list(map(int,input().split()))

diff = sum(n_list[1::2]) - sum(n_list[::2])

# N=3이고 홀수합이 더 많다면 불가능
if n == 3 and diff < 0 :
    print(-1)
# 그 외에는 절댓값의 차이 만큼 +1
else:
    print(abs(diff))
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
